### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ aims to expose how common Lisp constructs map to hardware.
 
 ## Building
 
+Must first run...
+
 1. `brew install llvm`
 2. `opam install llvm ocamlfind`
-3. `make`
+
+...before invoking `make`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ aims to expose how common Lisp constructs map to hardware.
 
 ## Building
 
-`brew install llvm` and `opam install llvm` before invoking `make`.
+1. `brew install llvm`
+2. `opam install llvm`
+3. `opam install ocamlfind`
+4. `make`
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ aims to expose how common Lisp constructs map to hardware.
 ## Building
 
 1. `brew install llvm`
-2. `opam install llvm`
-3. `opam install ocamlfind`
-4. `make`
+2. `opam install llvm ocamlfind`
+3. `make`
 
 ## How it works
 


### PR DESCRIPTION
Small pull request to update the build instructions to include `opam install ocamlfind`. Since I was doing this from never having installed any ocaml packages it turned out that `opam install llvm` didn't finish the trick. I was receiving the error:

``` shell
ocamlyacc parser.mly
ocamlfind ocamlc -g -w @5@8@10@11@12@14@23@24@26@29@40 -c -package llvm -linkpkg ast.mli
make: ocamlfind: No such file or directory
make: *** [ast.cmi] Error 1
```

Running `opam install ocamlfind` certainly fixed that.
